### PR TITLE
Use stdlib methods for file/dir operations, cleanup dir separator use

### DIFF
--- a/birdseye.py
+++ b/birdseye.py
@@ -20,13 +20,9 @@ import image_tools
 import disk_tools as disk
 import argparse
 import math
+import os.path
 
 import make_movie
-
-if sys.platform.startswith('darwin'):
-    slash = '/'
-else:
-    slash = '\\'    
 
 scale_div = 1
 
@@ -41,8 +37,8 @@ FORCE_WIDTH = True
 FORCE_EVEN = True
 
 SOURCE_FOLDER = '.'
-TEMP_FOLDER = '.' + slash + 'temp' + slash
-OUTPUT_FOLDER = '.' + slash + 'output' + slash
+TEMP_FOLDER = os.path.join('.', 'temp')
+OUTPUT_FOLDER = os.path.join('.', 'output')
 
 MAX_FILES = 100000
 MAX_LINES = 100000
@@ -213,7 +209,8 @@ def drawImages(output_file_name, allFiles, scale_div=1):
         new_h = int(region.size[1]*scale_div)
         region = region.resize((new_w,new_h), Image.ANTIALIAS)
 
-        fileImage = TEMP_FOLDER + os.path.split(f)[0].split(slash)[-1] + '_' +  os.path.split(f)[1] + '.png'
+        dirname, filename = os.path.split(f)
+        fileImage = os.path.join(TEMP_FOLDER, dirname.split(os.path.sep)[-1] + '_' + filename + '.png')
         region.save(fileImage, "PNG")
         del region
         fileImages.append(fileImage)
@@ -300,7 +297,8 @@ def createImage(target,first=True,index=0,movie=False, info = True, alphabetical
 
     allFileImages = []
     for i,f in enumerate(allFiles):
-        fileImage = TEMP_FOLDER + os.path.split(f)[0].split(slash)[-1] + '_' + os.path.split(f)[1] + '.png'
+        dirname, filename = os.path.split(f)
+        fileImage = os.path.join(TEMP_FOLDER, dirname.split(os.path.sep)[-1] + '_' + filename + '.png')
         allFileImages.append(fileImage)
 
     disk.makeFolder(TEMP_FOLDER)
@@ -316,7 +314,7 @@ def createImage(target,first=True,index=0,movie=False, info = True, alphabetical
     for image in folderImages:
         for match in allFileImages:
             if os.path.split(match)[1] in image:
-                runImages.append(TEMP_FOLDER + slash + image)
+                runImages.append(os.path.join(TEMP_FOLDER, image))
     runImages.sort()
 
     if alphabetical_sort:

--- a/disk_tools.py
+++ b/disk_tools.py
@@ -14,7 +14,11 @@ copy = shutil.copyfile
 move = shutil.move
 
 def open(f):
-    cmd = "xdg-open " + f
+    if sys.platform == "linux2":
+        cmd = "xdg-open " + f
+    else:
+        cmd = "open " + f
+
     try:
         response = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read()
     except subprocess.CalledProcessError as e:

--- a/disk_tools.py
+++ b/disk_tools.py
@@ -8,43 +8,13 @@ import string
 import os
 import sys
 import subprocess
+import shutil
 
-if sys.platform.startswith('darwin'):
-    delete_command = 'rm'
-    delete_folder_command = 'rm -r'
-    copy_command = 'cp'
-    move_command = 'mv'
-else:
-    delete_command = 'del'
-    delete_folder_command = 'rmdir /S /Q'
-    copy_command = 'copy'
-    rename_command = 'ren'
+copy = shutil.copyfile
+move = shutil.move
 
-def copy(f,new): 
-    cmd = copy_command + " " + f + " " + new
-    try:
-        response = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read()
-    except subprocess.CalledProcessError as e:
-        print cmd
-        print e.output
-    return new
-    
-def move(f,new): 
-    if sys.platform.startswith('darwin'):
-        cmd = move_command + " " + f + " " + new
-        try:
-            response = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read()
-        except subprocess.CalledProcessError as e:
-            print cmd
-            print e.output
-        return new
-    else:
-        copy(f,new)
-        cleanUp(f)
-            
-
-def open(f): 
-    cmd = "open " + f
+def open(f):
+    cmd = "xdg-open " + f
     try:
         response = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read()
     except subprocess.CalledProcessError as e:
@@ -55,28 +25,19 @@ def cleanUp(files):
     if type(files) != list:
         files = [files]
     for f in files:
-        cmd = delete_command + " " + f
-        try:
-            response = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read()
-        except subprocess.CalledProcessError as e:
-            print cmd
-            print e.output
+        os.remove(f)
 
 def makeFolder(folder):
-    cmd = "mkdir " + folder
     try:
-        response = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read()
-    except subprocess.CalledProcessError as e:
-        print cmd
-        print e.output
+        os.mkdir(folder)
+    except OSError as ex:
+        print ex
 
 def deleteFolder(folder):
-    cmd = delete_folder_command + ' ' + folder
     try:
-        response = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read()
-    except subprocess.CalledProcessError as e:
-        print cmd
-        print e.output
+        shutil.rmtree(folder)
+    except OSError as ex:
+        print ex
 
 if __name__ == '__main__':
     pass


### PR DESCRIPTION
I was trying to use this in Linux and ran into a number of issues with regards to first path separators, and then trying to call non-existent command lines.  This eliminates switching on platform and uses built in Python library calls to do file and directory operations.